### PR TITLE
[orchagent] Add TX error counter monitor functionality.

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -56,7 +56,8 @@ orchagent_SOURCES = \
             sfloworch.cpp \
             chassisorch.cpp \
             debugcounterorch.cpp \
-            natorch.cpp
+            natorch.cpp \
+            txmonitororch.cpp
 
 orchagent_SOURCES += flex_counter/flex_counter_manager.cpp flex_counter/flex_counter_stat_manager.cpp
 orchagent_SOURCES += debug_counter/debug_counter.cpp debug_counter/drop_counter.cpp

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -31,6 +31,8 @@
 #include "debugcounterorch.h"
 #include "directory.h"
 #include "natorch.h"
+#include "txmonitororch.h"
+
 
 using namespace swss;
 

--- a/orchagent/txmonitororch.cpp
+++ b/orchagent/txmonitororch.cpp
@@ -1,0 +1,367 @@
+/*
+ * Copyright (C) Mellanox Technologies, Ltd. 2001-2014 ALL RIGHTS RESERVED.
+ *
+ * This software product is a proprietary product of Mellanox Technologies, Ltd.
+ * (the "Company") and all right, title, and interest in and to the software product,
+ * including all associated intellectual property rights, are and shall
+ * remain exclusively with the Company.
+ *
+ * This software product is governed by the End User License Agreement
+ * provided with the software product.
+ *
+ */
+
+#include "txmonitororch.h"
+#include "portsorch.h"
+#include "select.h"
+#include "notifier.h"
+#include "redisclient.h"
+#include "sai_serialize.h"
+#include <inttypes.h>
+
+extern PortsOrch* gPortsOrch;
+
+
+TxMonitorOrch::TxMonitorOrch(TableConnector configDbConnector, TableConnector stateDbConnector) :
+        Orch(configDbConnector.first, configDbConnector.second),
+        m_countersDb(new DBConnector("COUNTERS_DB", 0)),
+        m_countersTable(new Table(m_countersDb.get(), COUNTERS_TABLE)),
+        m_countersPortNameMap(new Table(m_countersDb.get(), COUNTERS_PORT_NAME_MAP)),
+        m_monitorStateTable(stateDbConnector.first, stateDbConnector.second)
+{
+    SWSS_LOG_ENTER();
+
+    initDone = false;
+    m_pooling_period = Default_PoolingPeriod;
+    m_threshold = Default_Threshold;
+
+    initTimer();
+}
+
+
+TxMonitorOrch::~TxMonitorOrch(void)
+{
+    SWSS_LOG_ENTER();
+}
+
+
+void TxMonitorOrch::doTask(SelectableTimer &timer)
+{
+    SWSS_LOG_ENTER();
+
+    initMaps();
+
+    if (!initDone)
+    {
+        return;
+    }
+
+    txCounterCheck();
+}
+
+void TxMonitorOrch::doTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+
+    if (!gPortsOrch->allPortsReady())
+     {
+         return;
+     }
+
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+       KeyOpFieldsValuesTuple t = it->second;
+
+       string key = kfvKey(t);
+       string op = kfvOp(t);
+
+       if (op == SET_COMMAND)
+       {
+           updateParams(key, kfvFieldsValues(t));
+       }
+       else
+       {
+           SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
+       }
+
+       consumer.m_toSync.erase(it++);
+    }
+}
+
+
+void TxMonitorOrch::initMaps()
+{
+    SWSS_LOG_ENTER();
+
+    if (!gPortsOrch->allPortsReady() || initDone)
+    {
+        return;
+    }
+
+    mapPortToName();
+    initReadCounter();
+
+    initDone = true;
+}
+
+void TxMonitorOrch::insertInfoToDbState(string key, string val)
+{
+    SWSS_LOG_ENTER();
+
+    vector<FieldValueTuple> fieldValuesVector;
+    fieldValuesVector.emplace_back("Value", val);
+    m_monitorStateTable.set(key, fieldValuesVector);
+}
+
+
+void TxMonitorOrch::updateParams(const string& key, const vector<FieldValueTuple>& data)
+{
+    SWSS_LOG_ENTER();
+
+    if(key == KEY_PoolingPeriod)
+    {
+        setTimer(data);
+    }
+    else if (key == KEY_Threshold)
+    {
+        setThreshold(data);
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Unknown key %s", key.c_str());
+    }
+}
+
+
+
+void TxMonitorOrch::mapPortToName()
+{
+    SWSS_LOG_ENTER();
+
+    for (auto const &curr : gPortsOrch->getAllPorts())
+    {
+        string portName = curr.first;
+        Port port = curr.second;
+        string portOid;
+
+        if (port.m_type != Port::Type::PHY)
+        {
+            continue;
+        }
+
+        if (!m_countersPortNameMap->hget("", portName, portOid))
+        {
+            SWSS_LOG_ERROR("error getting port name from counters");
+            continue;
+        }
+        m_portsStringsMap[port.m_alias] = portOid;
+    }
+}
+
+void TxMonitorOrch::initReadCounter()
+{
+    SWSS_LOG_ENTER();
+
+    for (auto &entry : m_portsStringsMap)
+    {
+        string portAlias = entry.first;
+        string portOid = entry.second;
+        string portState = "OK";
+        string strVal;
+
+        if (!m_countersTable->hget(portOid, counterName, strVal))
+        {
+            SWSS_LOG_WARN("Error reading counters table");
+            SWSS_LOG_ERROR("Cannot take information from table for port %s", portOid.c_str());
+            strVal = "0";
+            portState = "UNKNOWN";
+        }
+
+        int newTxCounter;
+
+        try
+        {
+            newTxCounter = stoi(strVal);
+
+            if(newTxCounter < 0)
+            {
+                throw logic_error("Non-logical tx-counter value");
+            }
+        }
+        catch (...)
+        {
+            newTxCounter = 0;
+            portState = "UNKNOWN";
+
+            SWSS_LOG_ERROR("Tx-counter value invalid");
+        }
+
+        m_portsMap_txCounter[portAlias] = newTxCounter;
+        insertInfoToDbState(portAlias, portState);
+    }
+    m_monitorStateTable.flush();
+}
+
+
+
+void TxMonitorOrch::initTimer()
+{
+    SWSS_LOG_ENTER();
+
+    auto interv = timespec { .tv_sec = (int)m_pooling_period, .tv_nsec = 0 };
+    m_timer = new SelectableTimer(interv);
+    auto executor = new ExecutableTimer(m_timer, this, "Tx_Port_Monitor");
+    Orch::addExecutor(executor);
+    m_timer->start();
+}
+
+void TxMonitorOrch::setTimer(const vector<FieldValueTuple>& data)
+{
+    SWSS_LOG_ENTER();
+
+    int new_PoolingPeriod;
+
+    for (auto i : data)
+    {
+        new_PoolingPeriod = Default_PoolingPeriod;
+        const auto &field = fvField(i);
+        const auto &value = fvValue(i);
+
+        if (field == FIELD_VALUE)
+        {
+            try
+            {
+                new_PoolingPeriod = stoi(value);
+                if(new_PoolingPeriod <= 0)
+                {
+                    throw invalid_argument("Illegal pooling period");
+                }
+            }
+            catch(...)
+            {
+                SWSS_LOG_ERROR("Illegal pooling period");
+                continue;
+            }
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Unknown value type");
+            continue;
+        }
+
+        m_pooling_period = new_PoolingPeriod;
+    }
+
+    auto interv = timespec { .tv_sec = (int)m_pooling_period, .tv_nsec = 0 };
+    m_timer->setInterval(interv);
+    m_timer->reset();
+}
+
+void TxMonitorOrch::setThreshold(const vector<FieldValueTuple>& data)
+{
+    SWSS_LOG_ENTER();
+
+    int new_Threshold;
+
+    for (auto i : data)
+    {
+        new_Threshold = Default_Threshold;
+        const auto &field = fvField(i);
+        const auto &value = fvValue(i);
+
+        if (field == FIELD_VALUE)
+        {
+            try
+            {
+                new_Threshold = stoi(value);
+                if(new_Threshold <= 0)
+                {
+                    throw invalid_argument("Illegal threshold");
+                }
+            }
+            catch(...)
+            {
+                SWSS_LOG_ERROR("Illegal threshold");
+                continue;
+            }
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Unknown value type");
+            continue;
+        }
+
+        m_threshold = new_Threshold;
+    }
+}
+
+
+void TxMonitorOrch::txCounterCheck()
+{
+    SWSS_LOG_ENTER();
+
+    for (auto& i : m_portsMap_txCounter)
+    {
+        string portAlias = i.first;
+        int txCounter = i.second;
+
+        string portOid = m_portsStringsMap.find(portAlias)->second;
+        string strVal = readCounterForPort(portOid, counterName);
+
+        int newTxCounter;
+        string portState;
+
+        try
+        {
+            if(strVal == "-1")
+            {
+                throw logic_error("Missing tx-counter value");
+            }
+
+            newTxCounter = stoi(strVal);
+
+            if(newTxCounter < 0)
+            {
+                throw logic_error("Non-logical tx-counter value");
+            }
+        }
+        catch (...)
+        {
+            m_portsMap_txCounter[portAlias] = 0;
+
+            insertInfoToDbState(portAlias, "UNKNOWN");
+
+            SWSS_LOG_ERROR("Tx-counter value invalid");
+            continue;
+        }
+
+        if(newTxCounter - txCounter > (int)m_threshold)     /* Port is not valid */
+        {
+            portState = "NOT_OK";
+        }
+        else                                                /* Port is valid */
+        {
+            portState = "OK";
+        }
+
+        m_portsMap_txCounter[portAlias] = newTxCounter;
+        insertInfoToDbState(portAlias, portState);
+    }
+    m_monitorStateTable.flush();
+}
+
+string TxMonitorOrch::readCounterForPort(string oid, string counterName){
+    SWSS_LOG_ENTER();
+
+    string strVal;
+
+    if (!m_countersTable->hget(oid, counterName, strVal))
+    {
+        strVal = "-1";
+    }
+    return strVal;
+}
+
+
+

--- a/orchagent/txmonitororch.h
+++ b/orchagent/txmonitororch.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) Mellanox Technologies, Ltd. 2001-2014 ALL RIGHTS RESERVED.
+ *
+ * This software product is a proprietary product of Mellanox Technologies, Ltd.
+ * (the "Company") and all right, title, and interest in and to the software product,
+ * including all associated intellectual property rights, are and shall
+ * remain exclusively with the Company.
+ *
+ * This software product is governed by the End User License Agreement
+ * provided with the software product.
+ *
+ */
+
+#ifndef SRC_SONIC_SWSS_ORCHAGENT_TXMONITORORCH_H_
+#define SRC_SONIC_SWSS_ORCHAGENT_TXMONITORORCH_H_
+
+
+#include <string>
+#include <map>
+#include <array>
+
+#include "orch.h"
+#include "port.h"
+#include "timer.h"
+#include "selectabletimer.h"
+
+using namespace std;
+using namespace swss;
+
+static const string counterName = "SAI_PORT_STAT_IF_OUT_ERRORS";
+
+static const string FIELD_VALUE = "Value";
+
+static const string KEY_PoolingPeriod = "pooling_period";
+static const string KEY_Threshold = "threshold";
+
+#define Default_PoolingPeriod 60
+#define Default_Threshold 10
+
+class TxMonitorOrch : public Orch {
+
+    public:
+        TxMonitorOrch(TableConnector configDbConnector, TableConnector stateDbConnector);
+        virtual ~TxMonitorOrch(void);
+        void doTask(Consumer &consumer);
+        void doTask(SelectableTimer &timer);
+
+    private:
+        bool                initDone;
+        uint64_t            m_pooling_period;
+        uint64_t            m_threshold;
+        SelectableTimer     *m_timer;
+
+        Table               m_monitorStateTable;
+
+        shared_ptr<swss::DBConnector>     m_countersDb = nullptr;
+        shared_ptr<swss::Table>           m_countersTable = nullptr;
+        shared_ptr<swss::Table>           m_countersPortNameMap = nullptr;
+
+        map<string, int>            m_portsMap_txCounter;   //<alias, txCounter>
+        map<string, string>         m_portsStringsMap;      //<alias, oid>
+
+        void initMaps();
+        void insertInfoToDbState(string key, string val);
+        void updateParams(const string& key, const vector<FieldValueTuple>& data);
+        void mapPortToName();
+
+        void initReadCounter();
+        void initTimer();
+
+        void setTimer(const vector<FieldValueTuple>& data);
+        void setThreshold(const vector<FieldValueTuple>& data);
+
+        void txCounterCheck();
+        string readCounterForPort(string oid, string counterName);
+
+};
+
+
+#endif /* SRC_SONIC_SWSS_ORCHAGENT_TXMONITORORCH_H_ */


### PR DESCRIPTION
Signed-off-by: Noy Saban <noysa@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added new class TxMonitorOrch. It listens to tx-configuration changes (timer interval and threshold for tx-counter). In addition, every time-period of the timer, it monitors the tx-counter per port, and determine the port state according the threshold.

**Why I did it**
There was a need to add tx state per port.

**How I verified it**
Upload the version on switch and check the correlation between configuration, DB, etc. In addition verified with log prints that the desired behaviour achieved. 

**Details if related**
